### PR TITLE
Change the type of custom queue label from String to optional String

### DIFF
--- a/GCDKit/GCDQueue.swift
+++ b/GCDKit/GCDQueue.swift
@@ -71,10 +71,10 @@ public enum GCDQueue {
     /**
     Creates a custom queue to which blocks can be submitted serially.
     
-    - parameter label: A string label to attach to the queue to uniquely identify it in debugging tools such as Instruments, sample, stackshots, and crash reports.
+    - parameter label: A UnsafePointer<Int8> label to attach to the queue to uniquely identify it in debugging tools such as Instruments, sample, stackshots, and crash reports.
     - returns: A new custom serial queue.
     */
-    public static func createSerial(label: String) -> GCDQueue {
+    public static func createSerial(label: UnsafePointer<Int8> = nil) -> GCDQueue {
         
         return self.createCustom(isConcurrent: false, label: label, targetQueue: nil)
     }
@@ -82,11 +82,11 @@ public enum GCDQueue {
     /**
     Creates a custom queue and specifies a target queue to which blocks can be submitted serially.
     
-    - parameter label: A string label to attach to the queue to uniquely identify it in debugging tools such as Instruments, sample, stackshots, and crash reports.
+    - parameter label: A UnsafePointer<Int8> label to attach to the queue to uniquely identify it in debugging tools such as Instruments, sample, stackshots, and crash reports.
     - parameter targetQueue: The new target queue for the custom queue.
     - returns: A new custom serial queue.
     */
-    public static func createSerial(label: String, targetQueue: GCDQueue) -> GCDQueue {
+    public static func createSerial(label: UnsafePointer<Int8> = nil, targetQueue: GCDQueue) -> GCDQueue {
         
         return self.createCustom(isConcurrent: false, label: label, targetQueue: targetQueue)
     }
@@ -94,10 +94,10 @@ public enum GCDQueue {
     /**
     Creates a custom queue to which blocks can be submitted concurrently.
     
-    - parameter label: A string label to attach to the queue to uniquely identify it in debugging tools such as Instruments, sample, stackshots, and crash reports.
+    - parameter label: A UnsafePointer<Int8> label to attach to the queue to uniquely identify it in debugging tools such as Instruments, sample, stackshots, and crash reports.
     - returns: A new custom concurrent queue.
     */
-    public static func createConcurrent(label: String) -> GCDQueue {
+    public static func createConcurrent(label: UnsafePointer<Int8> = nil) -> GCDQueue {
         
         return self.createCustom(isConcurrent: true, label: label, targetQueue: nil)
     }
@@ -109,7 +109,7 @@ public enum GCDQueue {
     - parameter targetQueue: The new target queue for the custom queue.
     - returns: A new custom concurrent queue.
     */
-    public static func createConcurrent(label: String, targetQueue: GCDQueue) -> GCDQueue {
+    public static func createConcurrent(label: UnsafePointer<Int8> = nil, targetQueue: GCDQueue) -> GCDQueue {
         
         return self.createCustom(isConcurrent: true, label: label, targetQueue: targetQueue)
     }
@@ -302,7 +302,7 @@ public enum GCDQueue {
         }
     }
     
-    private static func createCustom(isConcurrent isConcurrent: Bool, label: String, targetQueue: GCDQueue?) -> GCDQueue {
+    private static func createCustom(isConcurrent isConcurrent: Bool, label: UnsafePointer<Int8> = nil, targetQueue: GCDQueue?) -> GCDQueue {
         
         let queue = GCDQueue.Custom(dispatch_queue_create(label, (isConcurrent ? DISPATCH_QUEUE_CONCURRENT : DISPATCH_QUEUE_SERIAL)))
         

--- a/GCDKit/GCDQueue.swift
+++ b/GCDKit/GCDQueue.swift
@@ -71,10 +71,10 @@ public enum GCDQueue {
     /**
     Creates a custom queue to which blocks can be submitted serially.
     
-    - parameter label: A UnsafePointer<Int8> label to attach to the queue to uniquely identify it in debugging tools such as Instruments, sample, stackshots, and crash reports.
+    - parameter label: A String label to attach to the queue to uniquely identify it in debugging tools such as Instruments, sample, stackshots, and crash reports.
     - returns: A new custom serial queue.
     */
-    public static func createSerial(label: UnsafePointer<Int8> = nil) -> GCDQueue {
+    public static func createSerial(label: String? = nil) -> GCDQueue {
         
         return self.createCustom(isConcurrent: false, label: label, targetQueue: nil)
     }
@@ -82,11 +82,11 @@ public enum GCDQueue {
     /**
     Creates a custom queue and specifies a target queue to which blocks can be submitted serially.
     
-    - parameter label: A UnsafePointer<Int8> label to attach to the queue to uniquely identify it in debugging tools such as Instruments, sample, stackshots, and crash reports.
+    - parameter label: A String label to attach to the queue to uniquely identify it in debugging tools such as Instruments, sample, stackshots, and crash reports.
     - parameter targetQueue: The new target queue for the custom queue.
     - returns: A new custom serial queue.
     */
-    public static func createSerial(label: UnsafePointer<Int8> = nil, targetQueue: GCDQueue) -> GCDQueue {
+    public static func createSerial(label: String? = nil, targetQueue: GCDQueue) -> GCDQueue {
         
         return self.createCustom(isConcurrent: false, label: label, targetQueue: targetQueue)
     }
@@ -94,10 +94,10 @@ public enum GCDQueue {
     /**
     Creates a custom queue to which blocks can be submitted concurrently.
     
-    - parameter label: A UnsafePointer<Int8> label to attach to the queue to uniquely identify it in debugging tools such as Instruments, sample, stackshots, and crash reports.
+    - parameter label: A String label to attach to the queue to uniquely identify it in debugging tools such as Instruments, sample, stackshots, and crash reports.
     - returns: A new custom concurrent queue.
     */
-    public static func createConcurrent(label: UnsafePointer<Int8> = nil) -> GCDQueue {
+    public static func createConcurrent(label: String? = nil) -> GCDQueue {
         
         return self.createCustom(isConcurrent: true, label: label, targetQueue: nil)
     }
@@ -109,7 +109,7 @@ public enum GCDQueue {
     - parameter targetQueue: The new target queue for the custom queue.
     - returns: A new custom concurrent queue.
     */
-    public static func createConcurrent(label: UnsafePointer<Int8> = nil, targetQueue: GCDQueue) -> GCDQueue {
+    public static func createConcurrent(label: String? = nil, targetQueue: GCDQueue) -> GCDQueue {
         
         return self.createCustom(isConcurrent: true, label: label, targetQueue: targetQueue)
     }
@@ -302,9 +302,14 @@ public enum GCDQueue {
         }
     }
     
-    private static func createCustom(isConcurrent isConcurrent: Bool, label: UnsafePointer<Int8> = nil, targetQueue: GCDQueue?) -> GCDQueue {
+    private static func createCustom(isConcurrent isConcurrent: Bool, label: String? = nil, targetQueue: GCDQueue?) -> GCDQueue {
         
-        let queue = GCDQueue.Custom(dispatch_queue_create(label, (isConcurrent ? DISPATCH_QUEUE_CONCURRENT : DISPATCH_QUEUE_SERIAL)))
+        let queue = GCDQueue.Custom(
+            dispatch_queue_create(
+                (label as NSString?)?.UTF8String ?? nil,
+                (isConcurrent ? DISPATCH_QUEUE_CONCURRENT : DISPATCH_QUEUE_SERIAL)
+            )
+        )
         
         if let target = targetQueue {
             


### PR DESCRIPTION
Hi, @JohnEstropia 
Thanks for your great lib.

I changed the type of label of the function that creates custom queue to UnsafePointer<Int8>, and applied the initial value to nil.

This changes is based on the following description in the 481-483 lines of dispatch/queue.h:

```
* @param label
* A string label to attach to the queue.
* This parameter is optional and may be NULL.
```

But it's OK to close this PR without merge, if you feel not good :bow:
