### PR TITLE
GCDQueue `suspend()` and `resume()`

### DIFF
--- a/GCDKitTests/GCDKitTests.swift
+++ b/GCDKitTests/GCDKitTests.swift
@@ -114,6 +114,19 @@ class GCDKitTests: XCTestCase {
             XCTAssertFalse(NSThread.isMainThread())
             dispatchExpectation.fulfill()
         }
+        
+        let suspendExpectation = self.expectationWithDescription("suspend queue expectation")
+        let suspendQueue = GCDQueue.createConcurrent("suspend")
+        suspendQueue.suspend()
+        var resumed = false
+        suspendQueue.async {
+            XCTAssertTrue(resumed)
+            suspendExpectation.fulfill()
+        }
+        mainQueue.after(1) {
+            resumed = true
+            suspendQueue.resume()
+        }
 
         self.waitForExpectationsWithTimeout(60, handler: nil)
     }

--- a/Sources/GCDQueue.swift
+++ b/Sources/GCDQueue.swift
@@ -271,6 +271,28 @@ public enum GCDQueue {
     }
     
     /**
+    Suspends invocation of blocks on this queue. The suspension occurs after the completion of any blocks running at the time of the call.
+    
+    - Note:
+        - Blocks remaining on the queue or submitted after the queue is suspended are delivered once the queue is resumed.
+        - No effect when the target represents a system queue.
+     
+    - attention: Each call to `suspend()` **must** be balanced by a call to `resume()` before the underlying queue is deallocated.
+    */
+    public func suspend() {
+        dispatch_suspend(self.dispatchQueue())
+    }
+    
+    /**
+    Resumes invocation of blocks on this queue.
+    
+    - attention: Each call to `resume()` **must** balance a call to `suspend()`
+    */
+    public func resume() {
+        dispatch_resume(self.dispatchQueue())
+    }
+    
+    /**
     Returns the dispatch_queue_t object associated with this value.
     
     - returns: The dispatch_queue_t object associated with this value.


### PR DESCRIPTION
Hey, this PR adds thin wrappers for `dispatch_suspend` and `dispatch_resume` to `GCDQueue`.

One gotcha with `dispatch_suspend` is that it must be balanced with a call to `dispatch_resume` before the queue is deallocated. If we want, we can handle unbalanced `suspend`s for the user with a thin class wrapper for custom queues that tracks `suspend` count and, on `deinit`, submits a barrier block to the target queue balancing `resume`s. Doing so would break clients that keep references to the underlying dispatch queue.
